### PR TITLE
improves development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,44 @@ You should familarize yourself with the various _response objects_, to understan
 
 To streamline and accelerate the development process, follow these steps:
 
+### Quick Start (Recommended)
+
 1. Install _n8n_ globally (`pnpm add -g n8n`).
-2. Set the `N8N_CUSTOM_EXTENSIONS` environment variable to the `/dist` directory of this repository.
-3. Enable hot reloading by setting the `N8N_DEV_RELOAD` environment variable to `true`.
-4. Run `pnpm run dev` to watch for changes and automatically rebuild the node as you develop.
-5. Start n8n with `n8n start` to launch the editor UI.
-6. Open the n8n editor UI in your browser.
+2. Install dependencies: `pnpm install`
+3. Run the full development environment: `pnpm run dev:full`
+4. Open the n8n editor UI in your browser (typically at http://localhost:5678).
+
+The `dev:full` script automatically:
+- Builds the project
+- Starts TypeScript compilation in watch mode
+- Launches n8n with the proper environment variables set
+- Enables hot reloading for development
+
+### Manual Development Setup
+
+If you prefer to run commands separately:
+
+1. Install _n8n_ globally (`pnpm add -g n8n`).
+2. Install dependencies: `pnpm install`
+3. Build the project: `pnpm build`
+4. Start TypeScript watch mode: `pnpm dev`
+5. In a separate terminal, start n8n: `pnpm run dev:n8n`
+
+### Alternative: System Environment Variables
+
+You can also set environment variables manually if preferred:
+- Set `N8N_CUSTOM_EXTENSIONS` to the `/dist` directory of this repository
+- Set `N8N_DEV_RELOAD` to `true`
+- Run `pnpm run dev` and `n8n start` separately
 
 You should now be able to search for and use the Brave Search node in your n8n workflows.
 
-> **Note:** When launching n8n locally for the first time, you will be prompted to create a user account. If you forget your credentials, you can reset n8n to its initial state by running `n8n user-management:reset`.
+### First-Time Setup Notes
 
-## Version history
-
-- 1.0.0 &mdash; Initial release of the Brave Search API n8n node
+> **Important:** When launching n8n locally for the first time, the startup process may take 1-2 minutes to initialize. Wait for the "Editor is now accessible via web browser" message in the terminal before opening your browser.
+> 
+> On first access to http://localhost:5678, you'll be prompted to create an admin user account for your local n8n instance. 
+> 
+> **Remember:** You'll need to configure your Brave Search API credentials in the n8n interface before the node will function. See the [Credentials](#credentials) section above for API key information.
+> 
+> If you encounter issues or need to start fresh, you can reset n8n to its initial state by running `n8n user-management:reset`.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "preinstall": "npx only-allow pnpm",
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
+    "dev:n8n": "cross-env N8N_CUSTOM_EXTENSIONS=./dist N8N_DEV_RELOAD=true n8n start",
+    "dev:full": "pnpm build && concurrently \"pnpm dev\" \"pnpm dev:n8n\"",
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes credentials package.json",
     "lintfix": "eslint nodes credentials package.json --fix",
@@ -50,6 +52,8 @@
   "devDependencies": {
     "@types/node": "22.16.5",
     "@typescript-eslint/parser": "8.38.0",
+    "concurrently": "^9.1.0",
+    "cross-env": "^7.0.3",
     "eslint": "8.57.1",
     "eslint-plugin-n8n-nodes-base": "1.16.3",
     "gulp": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,12 @@ importers:
       '@typescript-eslint/parser':
         specifier: 8.38.0
         version: 8.38.0(eslint@8.57.1)(typescript@5.8.3)
+      concurrently:
+        specifier: ^9.1.0
+        version: 9.2.0
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       eslint:
         specifier: 8.57.1
         version: 8.57.1
@@ -403,6 +409,11 @@ packages:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
 
+  concurrently@9.2.0:
+    resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
@@ -411,6 +422,11 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1463,6 +1479,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -1510,6 +1529,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -1595,6 +1618,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -1633,6 +1660,10 @@ packages:
   transliteration@2.3.5:
     resolution: {integrity: sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
   ts-api-utils@1.3.0:
@@ -2231,6 +2262,16 @@ snapshots:
       readable-stream: 2.3.8
       typedarray: 0.0.6
 
+  concurrently@9.2.0:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
   convert-source-map@1.9.0: {}
 
   copy-props@2.0.5:
@@ -2239,6 +2280,10 @@ snapshots:
       is-plain-object: 5.0.0
 
   core-util-is@1.0.3: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3416,6 +3461,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -3465,6 +3514,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -3559,6 +3610,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   sver-compat@1.5.0:
@@ -3600,6 +3655,8 @@ snapshots:
   transliteration@2.3.5:
     dependencies:
       yargs: 17.7.2
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@1.3.0(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
Rather than needing to set environment variables on the host machine, and run multiple terminal processes, this change enables the developer to simply run `pnpm run dev:full`, and work with a hot-reloaded codebase, and the local n8n frontend. README has also been updated to reflect modified development steps (retaining alternative instructions for those who prefer a more step-wise approach).