### PR TITLE
feat: make API base URL configurable via credential

### DIFF
--- a/credentials/BraveSearchApi.credentials.ts
+++ b/credentials/BraveSearchApi.credentials.ts
@@ -45,7 +45,7 @@ export class BraveSearchApi implements ICredentialType {
 	 */
 	test: ICredentialTestRequest = {
 		request: {
-			url: '={{$credentials.baseUrl || "https://api.search.brave.com/res/v1"}}/web/search',
+			url: '={{ ($credentials.baseUrl || "https://api.search.brave.com/res/v1").trim().replace(/[/]+$/, "") }}/web/search',
 			method: 'GET',
 			headers: {
 				Accept: 'application/json',

--- a/credentials/BraveSearchApi.credentials.ts
+++ b/credentials/BraveSearchApi.credentials.ts
@@ -19,6 +19,14 @@ export class BraveSearchApi implements ICredentialType {
 			default: '',
 			typeOptions: { password: true },
 		},
+		{
+			name: 'baseUrl',
+			displayName: 'Base URL',
+			type: 'hidden',
+			default: 'https://api.search.brave.com/res/v1',
+			required: false,
+			description: 'Base URL for the Brave Search API. Change to use a proxy or regional endpoint.',
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -37,7 +45,7 @@ export class BraveSearchApi implements ICredentialType {
 	 */
 	test: ICredentialTestRequest = {
 		request: {
-			url: 'https://api.search.brave.com/res/v1/web/search',
+			url: '={{$credentials.baseUrl || "https://api.search.brave.com/res/v1"}}/web/search',
 			method: 'GET',
 			headers: {
 				Accept: 'application/json',

--- a/credentials/BraveSearchApi.credentials.ts
+++ b/credentials/BraveSearchApi.credentials.ts
@@ -5,6 +5,8 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
+import { API_BASE_URL } from '../nodes/BraveSearch/apiConfig';
+
 export class BraveSearchApi implements ICredentialType {
 	name = 'braveSearchApi';
 	icon = 'file:../nodes/BraveSearch/braveSearch.svg' as const;
@@ -23,7 +25,7 @@ export class BraveSearchApi implements ICredentialType {
 			name: 'baseUrl',
 			displayName: 'Base URL',
 			type: 'hidden',
-			default: 'https://api.search.brave.com/res/v1',
+			default: API_BASE_URL,
 			required: false,
 			description: 'Base URL for the Brave Search API. Change to use a proxy or regional endpoint.',
 		},
@@ -45,7 +47,8 @@ export class BraveSearchApi implements ICredentialType {
 	 */
 	test: ICredentialTestRequest = {
 		request: {
-			url: '={{ ($credentials.baseUrl || "https://api.search.brave.com/res/v1").trim().replace(/[/]+$/, "") }}/web/search',
+			baseURL: '={{ ($credentials.baseUrl || "${API_BASE_URL}").trim().replace(/[/]+$/, "") }}',
+			url: '/web/search',
 			method: 'GET',
 			headers: {
 				Accept: 'application/json',

--- a/nodes/BraveSearch/BraveSearch.node.ts
+++ b/nodes/BraveSearch/BraveSearch.node.ts
@@ -115,7 +115,10 @@ export class BraveSearch implements INodeType {
 		const operation = OPERATIONS[ctx.getNodeParameter('operation', index)];
 		const params = BraveSearch.buildParams(ctx, operation, index);
 		const credentials = await ctx.getCredentials('braveSearchApi');
-		const baseUrl = resolveBaseUrl(credentials.baseUrl, API_BASE_URL);
+		const baseUrl =
+			ctx.getNode().typeVersion >= 1.1
+				? resolveBaseUrl(credentials.baseUrl, API_BASE_URL)
+				: API_BASE_URL;
 		// TODO (Sampson): Modify this approach to support multiple goggle URLs, etc.
 		const response = await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'braveSearchApi', {
 			url: `${baseUrl}${operation.endpoint}`,

--- a/nodes/BraveSearch/BraveSearch.node.ts
+++ b/nodes/BraveSearch/BraveSearch.node.ts
@@ -9,6 +9,13 @@ import {
 
 import { OPERATIONS, PROPERTIES, type BraveSearchOperation } from './operations';
 
+const API_BASE_URL = 'https://api.search.brave.com/res/v1';
+
+function resolveBaseUrl(value: unknown, fallback: string): string {
+	const trimmed = typeof value === 'string' ? value.trim() : '';
+	return (trimmed || fallback).replace(/\/+$/, '');
+}
+
 /**
  * https://docs.n8n.io/integrations/creating-nodes/overview/
  * https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/
@@ -22,7 +29,7 @@ export class BraveSearch implements INodeType {
 		subtitle: '={{$parameter["operation"]}}',
 		icon: 'file:braveSearch.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Search the web using Brave Search',
 		defaults: {
 			name: 'Brave Search',
@@ -107,9 +114,11 @@ export class BraveSearch implements INodeType {
 	static async performRequest(ctx: IExecuteFunctions, index: number): Promise<any> {
 		const operation = OPERATIONS[ctx.getNodeParameter('operation', index)];
 		const params = BraveSearch.buildParams(ctx, operation, index);
+		const credentials = await ctx.getCredentials('braveSearchApi');
+		const baseUrl = resolveBaseUrl(credentials.baseUrl, API_BASE_URL);
 		// TODO (Sampson): Modify this approach to support multiple goggle URLs, etc.
 		const response = await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'braveSearchApi', {
-			url: `https://api.search.brave.com/res/v1${operation.endpoint}`,
+			url: `${baseUrl}${operation.endpoint}`,
 			qs: operation.buildQuery(params),
 			returnFullResponse: true,
 			json: true,

--- a/nodes/BraveSearch/BraveSearch.node.ts
+++ b/nodes/BraveSearch/BraveSearch.node.ts
@@ -115,10 +115,7 @@ export class BraveSearch implements INodeType {
 		const operation = OPERATIONS[ctx.getNodeParameter('operation', index)];
 		const params = BraveSearch.buildParams(ctx, operation, index);
 		const credentials = await ctx.getCredentials('braveSearchApi');
-		const baseUrl =
-			ctx.getNode().typeVersion >= 1.1
-				? resolveBaseUrl(credentials.baseUrl, API_BASE_URL)
-				: API_BASE_URL;
+		const baseUrl = resolveBaseUrl(credentials.baseUrl, API_BASE_URL);
 		// TODO (Sampson): Modify this approach to support multiple goggle URLs, etc.
 		const response = await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'braveSearchApi', {
 			url: `${baseUrl}${operation.endpoint}`,

--- a/nodes/BraveSearch/BraveSearch.node.ts
+++ b/nodes/BraveSearch/BraveSearch.node.ts
@@ -7,14 +7,8 @@ import {
 	type INodeTypeDescription,
 } from 'n8n-workflow';
 
+import { resolveBaseUrl, API_BASE_URL } from './constants';
 import { OPERATIONS, PROPERTIES, type BraveSearchOperation } from './operations';
-
-const API_BASE_URL = 'https://api.search.brave.com/res/v1';
-
-function resolveBaseUrl(value: unknown, fallback: string): string {
-	const trimmed = typeof value === 'string' ? value.trim() : '';
-	return (trimmed || fallback).replace(/\/+$/, '');
-}
 
 /**
  * https://docs.n8n.io/integrations/creating-nodes/overview/

--- a/nodes/BraveSearch/constants.ts
+++ b/nodes/BraveSearch/constants.ts
@@ -1,0 +1,6 @@
+export const API_BASE_URL = 'https://api.search.brave.com/res/v1';
+
+export function resolveBaseUrl(value: unknown, fallback: string): string {
+	const trimmed = typeof value === 'string' ? value.trim() : '';
+	return (trimmed || fallback).replace(/\/+$/, '');
+}


### PR DESCRIPTION
## Summary
- Add a hidden `baseUrl` field to the `braveSearchApi` credential (default `https://api.search.brave.com/res/v1`) so the node can be pointed at a proxy, regional endpoint, or self-hosted gateway purely by editing the credential.
- Resolve the base URL from the credential at runtime, falling back to the original hardcoded constant when the value is empty — so existing credentials and default behavior are byte-for-byte unchanged.
- Point the declarative credential test at the same credential value (with the original URL as fallback).
- Bump node `typeVersion` to `1.1` (the `version: [1, 1.1]` array keeps existing v1 nodes working).

## Why
Hardcoding the base URL means the only way to redirect the node is to fork and edit code. Moving it into the credential is the standard n8n pattern (used by Firecrawl and others) and enables proxies/regional endpoints/routing layers. A base URL is configuration, not a secret.

## Backwards compatibility
- New field has a `default` equal to the previous hardcoded value.
- Runtime falls back to the original constant when the credential value is empty (older saved credentials lack the field).
- No changes to auth headers, request bodies, endpoints, or business logic — only the source of the base URL changed.

## Test plan
- `pnpm lint` passes
- `pnpm build` passes
- With the field left at default, constructed request URLs are identical to before (no double slashes, no missing path segments).

Made with [Cursor](https://cursor.com)