### PR TITLE
feat: add search aliases for improved node discoverability

### DIFF
--- a/nodes/BraveSearch/BraveSearch.node.json
+++ b/nodes/BraveSearch/BraveSearch.node.json
@@ -14,5 +14,16 @@
 				"url": "https://api-dashboard.search.brave.com/app/documentation"
 			}
 		]
-	}
+	},
+	"alias": [
+		"search",
+		"web search",
+		"serp",
+		"scrape",
+		"fetch",
+		"webscrape",
+		"brave",
+		"brave search",
+		"search engine"
+	]
 }


### PR DESCRIPTION
Adds a `codex.alias` list (search, web search, serp, scrape, fetch, brave, search engine, …) so the node surfaces for common web-search terms in the n8n nodes/tools search panel.

Made with [Cursor](https://cursor.com)